### PR TITLE
Fix the display of short commit hashes

### DIFF
--- a/src/main/kotlin/io/testaxis/intellijplugin/Models.kt
+++ b/src/main/kotlin/io/testaxis/intellijplugin/Models.kt
@@ -25,9 +25,11 @@ data class Build(
         if (pr?.isNotEmpty() == true) {
             append("Build for PR #$pr / ")
         }
-        append("Commit ${commit.subSequence(0, 8)}")
+        append("Commit ${shortCommitHash()}")
         append(" | ${createdAt.diffForHumans()}")
     }.toString()
+
+    fun shortCommitHash() = if (commit.length > 8) commit.subSequence(0, 8) else commit
 
     suspend fun retrieveTestCaseExecutions() =
         ServiceManager.getService(TestAxisApiService::class.java).getTestCaseExecutions(this)

--- a/src/main/kotlin/io/testaxis/intellijplugin/toolwindow/builds/tree/Nodes.kt
+++ b/src/main/kotlin/io/testaxis/intellijplugin/toolwindow/builds/tree/Nodes.kt
@@ -49,7 +49,7 @@ class BuildNode(val build: Build) : SimpleNode(), SecondaryInformationHolder {
             data.addText("PR #${build.pr} / ", SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES)
         }
 
-        data.addText("commit ${build.commit.subSequence(0, 8)}", SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES)
+        data.addText("commit ${build.shortCommitHash()}", SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES)
 
         data.setIcon(icon())
     }


### PR DESCRIPTION
Commit hashes shorter than 8 chars were triggering an exception